### PR TITLE
Added Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:20.04
+
+# Use bash for the shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Upgrade packages to latest version
+RUN apt-get update && apt-get upgrade -y
+
+# # Install GCC
+RUN apt-get update && apt-get install -y gcc-7 g++-7 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 60
+
+# Install Java Open JDK
+RUN apt-get update && apt-get install -y openjdk-11-jdk
+
+# Install Node.js
+# From: https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-in-docker
+# Create a script file sourced by both interactive and non-interactive bash shells
+ENV BASH_ENV "${HOME}/.bash_env"
+RUN touch "${BASH_ENV}"
+RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+# Install nvm
+RUN apt-get update && apt-get install -y curl && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | PROFILE="${BASH_ENV}" bash
+# Install node
+RUN nvm install 18
+
+# Install NASA DAA Displays
+RUN apt-get update && apt-get install -y build-essential rsync git
+COPY . /app/daa-displays
+WORKDIR /app/daa-displays
+RUN make

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  daa-displays:
+    image: daa-displays
+    container_name: daa-displays
+    entrypoint: /bin/bash
+    build: .
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/app/daa-displays
+    ports:
+      - "8082:8082"


### PR DESCRIPTION
# Description
To facilitate deployment for people trying the tool, this PR proposes a Docker image:
- Dockerfile installing the main dependencies, as well as the `daa-displays` tool
- Docker Compose file regrouping the main build and deployment instructions
- Added README instructions

# Usage
1. Build the image: `docker compose build`
2. Start the webserver: `docker compose up --detach`

# Testing
:x: I had to modify a few files to remove non-UTF characters for the code to compile:
```
        modified:   daidalus-submodules/v2.0.3 (modified content)
        modified:   daidalus-submodules/v2.0.4 (modified content)
        modified:   src/contrib/virtual-pilot/BatchSimDaidalus_2_3_1.java
        modified:   src/contrib/virtual-pilot/SimDaidalus_2_3_1_wind.java
        modified:   src/daa-logic/utils/DAAMonitorsV2.java
```
:heavy_check_mark: Was able to build the image (with file modifications, see above)
```shell
$ docker compose build
[+] Building 34.9s (18/18) FINISHED                                                                                                                               docker:default
 => [daa-displays internal] load build definition from Dockerfile                                                                                                           0.0s
 => => transferring dockerfile: 1.17kB                                                                                                                                      0.0s
 => [daa-displays internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                0.4s
 => [daa-displays internal] load .dockerignore                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                             0.0s
 => [daa-displays  1/12] FROM docker.io/library/ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b                                        0.0s
 => [daa-displays internal] load build context                                                                                                                              0.4s
 => => transferring context: 1.57MB                                                                                                                                         0.3s
 => CACHED [daa-displays  2/12] RUN apt-get update && apt-get upgrade -y                                                                                                    0.0s
 => CACHED [daa-displays  3/12] RUN apt-get update && apt-get install -y gcc-7 g++-7 &&     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 &&     update  0.0s
 => CACHED [daa-displays  4/12] RUN apt-get update && apt-get install -y openjdk-11-jdk                                                                                     0.0s
 => CACHED [daa-displays  5/12] RUN touch "/.bash_env"                                                                                                                      0.0s
 => CACHED [daa-displays  6/12] RUN echo '. "${BASH_ENV}"' >> ~/.bashrc                                                                                                     0.0s
 => CACHED [daa-displays  7/12] RUN apt-get update && apt-get install -y curl &&     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | PROFILE="/  0.0s
 => CACHED [daa-displays  8/12] RUN nvm install 18                                                                                                                          0.0s
 => CACHED [daa-displays  9/12] RUN apt-get update && apt-get install -y build-essential rsync git                                                                          0.0s
 => [daa-displays 10/12] COPY . /app/daa-displays                                                                                                                           9.6s
 => [daa-displays 11/12] WORKDIR /app/daa-displays                                                                                                                          0.1s
 => [daa-displays 12/12] RUN make                                                                                                                                          21.3s
 => [daa-displays] exporting to image                                                                                                                                       2.9s
 => => exporting layers                                                                                                                                                     2.9s
 => => writing image sha256:becdb006f53a890b96472930310360283ad042b666a3a265e71330ee16c279d0                                                                                0.0s 
 => => naming to docker.io/library/daa-displays                                                                                                                             0.0s 
 => [daa-displays] resolving provenance for metadata file                                                                                                                   0.0s 
[+] Building 1/1                                                                                                                                                                 
 ✔ daa-displays  Built
```
:heavy_check_mark: I was able to open the web URL and run DAA scenarios, just from the running Docker container